### PR TITLE
fixed response::GcmResponse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,5 +74,7 @@ pub use message::*;
 mod notification;
 pub use notification::*;
 
+pub use message::response::GcmError as Error;
+
 extern crate rustc_serialize;
 extern crate curl;

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests;
-mod response;
+pub mod response;
 
 pub use message::response::*;
 use notification::Notification;

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests;
-pub mod response;
+mod response;
 
 pub use message::response::*;
 use notification::Notification;

--- a/src/message/response.rs
+++ b/src/message/response.rs
@@ -2,7 +2,7 @@
 pub struct GcmResponse {
   pub message_id: Option<u64>,
   pub error: Option<String>,
-  pub multicast_id: Option<u64>,
+  pub multicast_id: Option<i64>,
   pub success: Option<u64>,
   pub failure: Option<u64>,
   pub canonical_ids: Option<u64>,


### PR DESCRIPTION
 multicast_id can actually be be negative (i just got back "-1" from the gcm server), so it has to be i64 instead of u64

using 

```
json::decode(body).unwrap()
```

in message::parse_response without checking the Result for errors also seems unsafe to me. It should return GcmError::InvalidJsonBody, so that it can be properly handled instead of just panicking.
